### PR TITLE
add float round checker: f32 and f64 round

### DIFF
--- a/src/analysis/callgraph.rs
+++ b/src/analysis/callgraph.rs
@@ -1,0 +1,40 @@
+use std::collections::HashSet;
+
+use rustc_public::{mir::{mono::Instance, TerminatorKind}, ty::{RigidTy, TyKind}, ItemKind};
+
+pub fn compute_instances() -> HashSet<Instance> {
+    let mut local_instances = vec![];
+    for item in rustc_public::all_local_items() {
+        if let ItemKind::Fn = item.kind()
+            && !item.requires_monomorphization()
+            && let Ok(instance) = Instance::try_from(item) {
+                local_instances.push(instance);
+        }
+    }
+    // for instance in local_instances {
+        // println!("{}", instance.name());
+    // }
+
+    let mut worklist = local_instances.clone();
+    let mut nodes: HashSet<Instance> = local_instances.into_iter().collect();
+    while let Some(curr) = worklist.pop() {
+        if let Some(ref body) = curr.body() {
+            for block in &body.blocks {
+                if let TerminatorKind::Call {
+                    ref func,
+                    ..
+                } = block.terminator.kind {
+                    let fn_ty = func.ty(body.locals()).unwrap();
+                    if let TyKind::RigidTy(RigidTy::FnDef(fn_def, args)) = fn_ty.kind() {
+                        let instance = Instance::resolve(fn_def, &args).unwrap();
+                        if nodes.insert(instance) {
+                            worklist.push(instance);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return nodes
+}

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1,1 +1,2 @@
 // pub mod graph;
+pub mod callgraph;

--- a/src/checker/mod.rs
+++ b/src/checker/mod.rs
@@ -1,4 +1,4 @@
-use crate::anchor_info::{AnchorAccountKind, find_to_account_metas, local_anchor_accounts};
+use crate::{analysis::callgraph, anchor_info::{find_to_account_metas, local_anchor_accounts, AnchorAccountKind}};
 
 pub fn detect_duplicate_mutable_account() {
     let res = find_to_account_metas();
@@ -46,6 +46,20 @@ pub fn detect_duplicate_mutable_account() {
                     }
                 }
             }
+        }
+    }
+}
+
+const F32_ROUND: &'static str = "f32::<impl f32>::round";
+const F64_ROUND: &'static str = "f64::<impl f64>::round";
+
+pub fn detect_float_round_fn() {
+    let instances = callgraph::compute_instances();
+    for instance in instances {
+        let name = instance.name();
+        println!("{name}");
+        if name.contains(F32_ROUND) || name.contains(F64_ROUND) {
+            println!("Contains f32::round or f64::round: {}", name);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,22 +6,23 @@ extern crate rustc_interface;
 extern crate rustc_middle;
 extern crate rustc_public;
 
+use rustc_public::mir::mono::Instance;
 use rustc_public::mir::Body;
+use rustc_public::mir::TerminatorKind;
+use rustc_public::ty::RigidTy;
+use rustc_public::ty::TyKind;
 use rustc_public::CompilerError;
 use rustc_public::run;
+use rustc_public::ItemKind;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ops::ControlFlow;
 use std::process::ExitCode;
 
 use crate::anchor_info::entry_instance;
-use rustc_public::CompilerError;
-use rustc_public::run;
-use std::ops::ControlFlow;
-use std::process::ExitCode;
-
 use crate::anchor_info::{extract_discriminators, extract_program_id};
 use crate::checker::detect_duplicate_mutable_account;
+use crate::checker::detect_float_round_fn;
 
 mod analysis;
 mod anchor_info;
@@ -64,7 +65,8 @@ fn demo_analysis() -> ControlFlow<()> {
         println!("{:?}", post_dominators);
     }
 
-    detect_duplicate_mutable_account();
+    detect_float_round_fn();
+    // detect_duplicate_mutable_account();
 
     ControlFlow::Continue(())
 }


### PR DESCRIPTION
Floats (f32, f64) are unsafe in Solana programs.
Use fixed-point integers instead. 

To find this vulnerability:
1. Add analysis to collect all the callees in a program.
2. Add a checker to find f32 and f64 round operation in the callees.
3. If found, report the float round error.


